### PR TITLE
[CORE-869]Roles to limit permission by environment

### DIFF
--- a/app/controllers/concerns/current_environment.rb
+++ b/app/controllers/concerns/current_environment.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module CurrentEnvironment
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_environment
+    helper_method :current_environment
+  end
+
+  protected
+
+  def current_environment
+    @environment
+  end
+
+  def require_environment
+    @environment = (Environment.find_by_param!(params[:environment_id]) if params[:environment_id])
+  end
+end

--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -4,7 +4,7 @@ class EnvironmentsController < ResourceController
   before_action :set_resource, only: [:show, :update, :destroy, :new, :create]
 
   def new
-    super(template: :show)
+    super(template: :new)
   end
 
   def create

--- a/app/controllers/user_environment_roles_controller.rb
+++ b/app/controllers/user_environment_roles_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+class UserEnvironmentRolesController < ApplicationController
+  include CurrentEnvironment
+
+  # TODO: This is some CanCan shit, find out if we need to tweak something
+  before_action :authorize_resource!
+
+  def index
+    options = params.to_unsafe_h
+    options[:environment_id] = current_environment.id # override permalink with id
+    options[:role_id] = Role::VIEWER.id if options[:role_id].blank? # force the join so we get environment_role_id
+
+    @pagy, @users = pagy(
+      User.search_by_criteria(options),
+      page: params[:page],
+      items: 15
+    )
+    @users = @users.select('users.*, user_environment_roles.role_id AS user_environment_role_id') # avoid breaking joins
+
+    respond_to do |format|
+      format.html
+      format.json { render json: {users: @users} }
+    end
+  end
+
+  def create
+    user = User.find(params[:user_id])
+    uer = UserEnvironmentRole.where(user: user, environment: current_environment).first_or_initialize
+    uer.role_id = params[:role_id].presence
+
+    if uer.role_id
+      uer.save!
+      user.update!(access_request_pending: false)
+    elsif uer.persisted?
+      uer.destroy!
+    end
+
+    role_name = (uer.role&.display_name || 'None')
+    Rails.logger.info(
+      "#{current_user.name_and_email} set the role #{role_name} to #{user.name} on environment #{current_environment.name}"
+    )
+
+    if request.xhr?
+      render plain: "Saved!"
+    else
+      redirect_back fallback_location: "/", notice: "Saved!"
+    end
+  end
+end

--- a/app/controllers/user_environment_roles_controller.rb
+++ b/app/controllers/user_environment_roles_controller.rb
@@ -2,7 +2,6 @@
 class UserEnvironmentRolesController < ApplicationController
   include CurrentEnvironment
 
-  # TODO: This is some CanCan shit, find out if we need to tweak something
   before_action :authorize_resource!
 
   def index

--- a/app/controllers/user_project_roles_controller.rb
+++ b/app/controllers/user_project_roles_controller.rb
@@ -14,6 +14,7 @@ class UserProjectRolesController < ApplicationController
       page: params[:page],
       items: 15
     )
+
     @users = @users.select('users.*, user_project_roles.role_id AS user_project_role_id') # avoid breaking joins
 
     respond_to do |format|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,7 +75,7 @@ module ApplicationHelper
     case resource
     when Project, DeployGroup, Environment, User, Samson::Secrets::VaultServer then [resource.name, resource]
     when Command then ["Command ##{resource.id}", resource]
-    when UserProjectRole then ["Role for ##{resource.user.name}", resource.user]
+    when UserProjectRole, UserEnvironmentRole then ["Role for ##{resource.user.name}", resource.user]
     when Stage then
       name = resource.name
       name = (resource.lock.warning? ? warning_icon : lock_icon) + " " + name if resource.lock

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -30,10 +30,6 @@ module ProjectsHelper
     current_user.admin_for?(@project)
   end
 
-  def deployer_for_stage?(stage)
-    current_user.deployer_for?(@project, stage.environments)
-  end
-
   def deployer_for_project?
     current_user.deployer_for?(@project)
   end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -30,6 +30,10 @@ module ProjectsHelper
     current_user.admin_for?(@project)
   end
 
+  def deployer_for_stage?(stage)
+    current_user.deployer_for?(@project, stage.environments)
+  end
+
   def deployer_for_project?
     current_user.deployer_for?(@project)
   end

--- a/app/helpers/stages_helper.rb
+++ b/app/helpers/stages_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 module StagesHelper
+  def deployer_for_stage?(stage)
+    current_user.deployer_for?(@project, stage.environments)
+  end
+
   def edit_command_link(command)
     title = (command.global? ? "Edit global command" : "Edit")
     icon = (command.global? ? "glyphicon-globe" : "glyphicon-edit")

--- a/app/helpers/user_environment_roles_helper.rb
+++ b/app/helpers/user_environment_roles_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module UserEnvironmentRolesHelper
+  # multiple are checked, but browser only shows last
+  def user_environment_role_radio(user, role_name, role_id, user_environment_role_id)
+    super_admin = (user.role_id == Role::SUPER_ADMIN.id)
+    user_role_is_inferior = user.role_id < role_id.to_i
+    # Environment roles are meant only to limit, so the user
+    # can't be set to a level above their current level.
+    disabled = super_admin || user_role_is_inferior
+
+    global_access = (user.role_id >= role_id.to_i)
+    environment_access = (user_environment_role_id && user_environment_role_id.to_i >= role_id.to_i)
+    checked = environment_access || !role_id
+    title = "User is a global #{user.role.name.capitalize}" if global_access
+
+    label_tag nil, class: ('disabled' if disabled), title: title do
+      radio_button_tag(:role_id, role_id.to_s, checked, disabled: disabled) <<
+        " " <<
+        role_name.titlecase
+    end
+  end
+end

--- a/app/helpers/user_environment_roles_helper.rb
+++ b/app/helpers/user_environment_roles_helper.rb
@@ -8,10 +8,10 @@ module UserEnvironmentRolesHelper
     # can't be set to a level above their current level.
     disabled = super_admin || user_role_is_inferior
 
-    global_access = (user.role_id >= role_id.to_i)
+    global_access = (user.role_id < role_id.to_i)
     environment_access = (user_environment_role_id && user_environment_role_id.to_i >= role_id.to_i)
     checked = environment_access || !role_id
-    title = "User is a global #{user.role.name.capitalize}" if global_access
+    title = "User is a global #{user.role.name.capitalize}" if disabled && global_access
 
     label_tag nil, class: ('disabled' if disabled), title: title do
       radio_button_tag(:role_id, role_id.to_s, checked, disabled: disabled) <<

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -1,4 +1,3 @@
-require 'pry'
 # frozen_string_literal: true
 class AccessControl
   class << self

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -1,3 +1,4 @@
+require 'pry'
 # frozen_string_literal: true
 class AccessControl
   class << self
@@ -25,7 +26,7 @@ class AccessControl
           end
         else raise ArgumentError, "Unsupported action #{action}"
         end
-      when :projects, :build_commands, :stages, :user_project_roles
+      when :projects, :build_commands, :stages, :user_project_roles, :user_environment_roles
         case action
         when :read then true
         when :write then user.admin_for?(scope)
@@ -61,6 +62,7 @@ class AccessControl
     private
 
     def can_deploy_anything?(user)
+      # TODO: Add to this?
       user.deployer? || user.user_project_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?
     end
 

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -62,8 +62,10 @@ class AccessControl
     private
 
     def can_deploy_anything?(user)
-      # TODO: Add to this?
-      user.deployer? || user.user_project_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?
+      user.deployer? ||
+        user.user_project_roles.where('role_id >= ?', Role::DEPLOYER.id).exists? ||
+        user.user_environment_roles.empty? ||
+        user.user_environment_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?
     end
 
     def can_lock_stage?(user, stage)

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -61,10 +61,10 @@ class AccessControl
     private
 
     def can_deploy_anything?(user)
-      user.deployer? ||
-        user.user_project_roles.where('role_id >= ?', Role::DEPLOYER.id).exists? ||
-        user.user_environment_roles.empty? ||
-        user.user_environment_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?
+      (user.deployer? ||
+        user.user_project_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?) &&
+        (user.user_environment_roles.empty? ||
+        user.user_environment_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?)
     end
 
     def can_lock_stage?(user, stage)

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -8,6 +8,8 @@ class Environment < ActiveRecord::Base
   include SoftDeleteWithDestroy
 
   has_many :deploy_groups, dependent: :destroy
+  has_many :user_environment_roles, dependent: :destroy
+  has_many :users, through: :user_environment_roles, inverse_of: :environments
   has_many :template_stages, -> { where(is_template: true) },
     through: :deploy_groups, class_name: 'Stage', inverse_of: nil
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,6 +127,7 @@ class User < ActiveRecord::Base
 
   def can_deploy_in_environments?(environments)
     return true unless environments
+    environments = [environments] unless environments.is_a? Enumerable
     environments.all? do |environment|
       uer = user_environment_roles.find_by(environment: environment)
       !uer || uer.deployer?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,8 +116,9 @@ class User < ActiveRecord::Base
     admin? || !!project_role_for(project)&.admin?
   end
 
-  def deployer_for?(project, environment = nil)
-    (deployer? || !!project_role_for(project)&.deployer?) && can_deploy_in_environment?(environment)
+  def deployer_for?(project, environments = nil)
+    # binding.pry
+    (deployer? || !!project_role_for(project)&.deployer?) && can_deploy_in_environments?(environments)
   end
 
   def project_role_for(project)
@@ -126,10 +127,12 @@ class User < ActiveRecord::Base
 
   private
 
-  def can_deploy_in_environment?(environment)
-    return true unless environment
-    return true unless uer = user_environment_roles.find_by(environment: environment)
-    uer.deployer?
+  def can_deploy_in_environments?(environments)
+    environments.all? do |environment|
+      return true unless environment
+      return true unless uer = user_environment_roles.find_by(environment: environment)
+      uer.deployer?
+    end
   end
 
   def destroy_user_project_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,9 @@ class User < ActiveRecord::Base
   has_many :stars, dependent: :destroy
   has_many :locks, dependent: :destroy
   has_many :user_project_roles, dependent: :destroy
+  has_many :user_environment_roles, dependent: :destroy
   has_many :projects, through: :user_project_roles, inverse_of: :users
+  has_many :environments, through: :user_environment_roles, inverse_of: :users
   has_many :csv_exports, dependent: :destroy
   has_many :builds, dependent: nil, foreign_key: :created_by, inverse_of: :creator
   has_many :jobs, dependent: nil, inverse_of: :user
@@ -32,6 +34,8 @@ class User < ActiveRecord::Base
   validates :github_username, uniqueness: {case_sensitive: false}, format: GITHUB_USERNAME_REGEX, allow_blank: true
 
   before_soft_delete :destroy_user_project_roles
+  #TODO: Implement this
+  before_soft_delete :destroy_user_environment_roles
 
   scope :search, ->(query) {
     if query.blank?
@@ -42,11 +46,11 @@ class User < ActiveRecord::Base
     end
   }
 
-  def self.with_role(role_id, project_id)
-    if project_id.present?
-      join_condition = "users.id = user_project_roles.user_id AND user_project_roles.project_id = #{project_id.to_i}"
-      joins("LEFT OUTER JOIN user_project_roles ON #{join_condition}").
-        where('users.role_id >= ? OR user_project_roles.role_id >= ?', role_id, role_id)
+  def self.with_role(role_id, resource_id, resource_type)
+    if resource_id.present?
+      join_condition = "users.id = user_#{resource_type}_roles.user_id AND user_#{resource_type}_roles.#{resource_type}_id = #{resource_id.to_i}"
+      joins("LEFT OUTER JOIN user_#{resource_type}_roles ON #{join_condition}").
+        where("users.role_id >= ? OR user_#{resource_type}_roles.role_id >= ?", role_id, role_id)
     else
       where('users.role_id >= ?', role_id)
     end
@@ -56,7 +60,8 @@ class User < ActiveRecord::Base
   def self.search_by_criteria(criteria)
     scope = super
     if role_id = criteria[:role_id].presence
-      scope = scope.with_role(role_id, criteria[:project_id])
+      resource_type = [:project_id, :environment_id].find{ |resource| criteria[resource].present? }
+      scope = scope.with_role(role_id, criteria[resource_type], resource_type.to_s.gsub('_id', ''))
     end
     if email = criteria[:email].presence
       scope = scope.where(email: email)
@@ -111,8 +116,8 @@ class User < ActiveRecord::Base
     admin? || !!project_role_for(project)&.admin?
   end
 
-  def deployer_for?(project)
-    deployer? || !!project_role_for(project)&.deployer?
+  def deployer_for?(project, environment = nil)
+    (deployer? || !!project_role_for(project)&.deployer?) && can_deploy_in_environment?(environment)
   end
 
   def project_role_for(project)
@@ -120,6 +125,12 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def can_deploy_in_environment?(environment)
+    return true unless environment
+    return true unless uer = user_environment_roles.find_by(environment: environment)
+    uer.deployer?
+  end
 
   def destroy_user_project_roles
     user_project_roles.each(&:destroy)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,6 @@ class User < ActiveRecord::Base
   validates :github_username, uniqueness: {case_sensitive: false}, format: GITHUB_USERNAME_REGEX, allow_blank: true
 
   before_soft_delete :destroy_user_project_roles
-  #TODO: Implement this
   before_soft_delete :destroy_user_environment_roles
 
   scope :search, ->(query) {
@@ -117,7 +116,6 @@ class User < ActiveRecord::Base
   end
 
   def deployer_for?(project, environments = nil)
-    # binding.pry
     (deployer? || !!project_role_for(project)&.deployer?) && can_deploy_in_environments?(environments)
   end
 
@@ -128,14 +126,20 @@ class User < ActiveRecord::Base
   private
 
   def can_deploy_in_environments?(environments)
+    return true unless environments
     environments.all? do |environment|
-      return true unless environment
-      return true unless uer = user_environment_roles.find_by(environment: environment)
-      uer.deployer?
+      uer = user_environment_roles.find_by(environment: environment)
+      !uer || uer.deployer?
     end
   end
 
   def destroy_user_project_roles
     user_project_roles.each(&:destroy)
   end
+
+
+  def destroy_user_environment_roles
+    user_environment_roles.each(&:destroy)
+  end
+
 end

--- a/app/models/user_environment_role.rb
+++ b/app/models/user_environment_role.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class UserEnvironmentRole < ActiveRecord::Base
+  include HasRole
+  extend AuditOnAssociation
+
+  audited
+  audits_on_association :user, :user_environment_roles do |user|
+    user.user_environment_roles.map { |uer| [uer.environment.permalink, uer.role_id] }.to_h
+  end
+
+  belongs_to :environment, inverse_of: :user_environment_roles
+  belongs_to :user, inverse_of: :user_environment_roles
+
+  ROLES = [Role::VIEWER, Role::DEPLOYER].freeze
+
+  validates_presence_of :environment, :user
+  validates :role_id, inclusion: {in: ROLES.map(&:id)}
+  validates_uniqueness_of :environment_id, scope: :user_id
+end

--- a/app/views/deploys/_buddy_check.html.erb
+++ b/app/views/deploys/_buddy_check.html.erb
@@ -20,7 +20,7 @@
       <% confirm = "Are you sure this is an emergency and you cannot find a buddy?\n#{strip_tags(details)}" %>
       <%= link_to "Bypass", buddy_check_project_deploy_path(@project, @deploy), method: :post, data: {confirm: confirm}, class: "btn btn-danger" %>
     </div>
-  <% elsif deployer_for_project? %>
+  <% elsif deployer_for_stage?(@deploy.stage) %>
     <p>This deploy requires a buddy.</p>
     <div class="buddy-approval">
       <%= link_to "Approve", buddy_check_project_deploy_path(@project, @deploy), method: :post, class: "btn btn-primary btn-xl" %>

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -2,7 +2,7 @@
   <%= "#{@project.name} - Deploy ##{@deploy.id}" %>
 
   <div class="pull-right">
-    <% if deployer_for_project? %>
+    <% if deployer_for_stage?(@deploy.stage) %>
       <%= redeploy_button %>
 
       <% if @deploy.succeeded? && next_stage = @deploy.stage.next_stage %>

--- a/app/views/environments/new.html.erb
+++ b/app/views/environments/new.html.erb
@@ -1,10 +1,8 @@
-<%= page_title 'Edit Environment' %>
+<%= page_title 'New Environment' %>
 
 <%= render_locks @environment %>
 
-<%= render "shared/environment_tabs", environment: @environment, active: 'environment' %>
-
-<section class='clearfix tabs'>
+<section>
   <%= form_for @environment, html: { class: "form-horizontal" } do |form| %>
     <%= render 'shared/errors', object: @environment %>
 

--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <td align="right">
-    <% if deployer_for_project? %>
+    <% if deployer_for_stage?(stage) %>
       <%= deploy_link @project, stage %>
     <% end %>
   </td>

--- a/app/views/releases/_deploy_to_button.html.erb
+++ b/app/views/releases/_deploy_to_button.html.erb
@@ -4,9 +4,11 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <% stages.each do |stage| %>
-      <li>
-        <%= link_to_deploy_stage(stage, release) %>
-      </li>
+    <% if deployer_for_stage?(stage) %>
+        <li>
+          <%= link_to_deploy_stage(stage, release) %>
+        </li>
+    <% end %>
     <% end %>
   </ul>
 </div>

--- a/app/views/shared/_environment_tabs.html.erb
+++ b/app/views/shared/_environment_tabs.html.erb
@@ -1,0 +1,9 @@
+<ul class="nav nav-tabs">
+  <li class="<%= 'active' if active == 'environment' %>">
+    <%= link_to "Edit Environment", environment %>
+  </li>
+
+  <li class="<%= 'active' if active == 'user_environment_roles' %>">
+    <%= link_to icon_tag('user'), environment_user_environment_roles_path(environment) %>
+  </li>
+</ul>

--- a/app/views/shared/_user_environment_role.html.erb
+++ b/app/views/shared/_user_environment_role.html.erb
@@ -1,0 +1,6 @@
+<%= form_tag user_environment_roles_path(environment_id: environment.id, user_id: user.id), class: 'autosubmit' do %>
+  <% options = [['None', nil]] + UserEnvironmentRole::ROLES.map { |r| [r.name, r.id] } %>
+  <% options.each do |name, id| %>
+    <%= user_environment_role_radio user, name, id, user_environment_role_id %>
+  <% end %>
+<% end %>

--- a/app/views/user_environment_roles/_search_bar.html.erb
+++ b/app/views/user_environment_roles/_search_bar.html.erb
@@ -1,0 +1,29 @@
+<%# used by multiple views %>
+<%= form_tag '?', method: :get do %>
+  <div class="col-md-5 clearfix">&nbsp;</div>
+
+  <div class="col-md-3 clearfix">
+    <%= text_field_tag :search, params[:search], class: 'form-control', placeholder: 'Search' %>
+  </div>
+
+  <div class="col-md-1 clearfix">
+    <%= select_tag :integration, options_for_select([['', nil], ['Integration', 'true'], ['Regular', 'false']], params[:integration]), class: 'form-control' %>
+  </div>
+
+  <div class="col-md-2 clearfix">
+    <% roles = [['', '']] + (system_level ? Role.all[1..-1] : ::UserEnvironmentRole::ROLES).map { |r| [r.name.capitalize, r.id] } %>
+    <%= select_tag :role_id, options_for_select(roles, params[:role_id]), class: 'form-control' %>
+  </div>
+
+  <% unless system_level %>
+    <% if @environment %>
+      <%= hidden_field_tag :environment_id, @environment.id %>
+    <% else %>
+      <%= hidden_field_tag :user_id, @user.id %>
+    <% end %>
+  <% end %>
+
+  <div class="col-md-1 clearfix">
+    <%= submit_tag "Search", class: "btn btn-default form-control" %>
+  </div>
+<% end %>

--- a/app/views/user_environment_roles/_user_environment_role.html.erb
+++ b/app/views/user_environment_roles/_user_environment_role.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td><%= user.id %></td>
+  <td><%= link_to_if can?(:write, :users), user.name, user %></td>
+  <td><%= user.email %></td>
+  <td class="editable-role">
+    <%= render partial: 'shared/user_environment_role', locals: {user: user, environment: @environment, user_environment_role_id: user.user_environment_role_id} %>
+  </td>
+</tr>

--- a/app/views/user_environment_roles/index.html.erb
+++ b/app/views/user_environment_roles/index.html.erb
@@ -1,0 +1,36 @@
+<% page_title "Users" %>
+
+<%= render 'shared/environment_tabs', environment: @environment, active: "user_environment_roles" %>
+
+<section id="user-environment-roles" class="tabs">
+  <h2 class="section-subtitle">Environment Level Role Restrictions</h2>
+
+  <%= render 'user_environment_roles/search_bar', system_level: false %>
+
+  <div class="users-csv">
+    <%= link_to "Download as CSV", new_csv_export_path(format: :csv, type: :users, environment_id: @environment.id) %>
+  </div>
+
+  <table class="table table-hover table-condensed">
+    <thead>
+    <tr>
+      <th><%= sortable "id" %></th>
+      <th><%= sortable "name" %></th>
+      <th><%= sortable "email" %></th>
+      <th>ROLE</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% if @users.length == 0 %>
+      <tr>
+        <td>No users found.</td>
+      </tr>
+    <% else %>
+        <%= render partial: 'user_environment_role', collection: @users, as: :user %>
+    <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @pagy %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Samson::Application.routes.draw do
     resources :webhooks, only: [:index, :create, :update, :destroy]
     resources :outbound_webhooks, only: [:index, :create, :update, :destroy]
     resources :references, only: [:index]
-    resources :user_project_roles, only: [:index]
+    resources :user_environment_roles, only: [:index]
 
     member do
       get :deploy_group_versions
@@ -58,6 +58,7 @@ Samson::Application.routes.draw do
   end
 
   resources :user_project_roles, only: [:index, :create]
+  resources :user_environment_roles, only: [:index, :create]
   resources :locks, only: [:index, :create, :destroy]
 
   resources :deploys, only: [:index] do
@@ -75,7 +76,9 @@ Samson::Application.routes.draw do
 
   resources :access_tokens, only: [:index, :new, :create, :destroy]
 
-  resources :environments, except: [:edit]
+  resources :environments, except: [:edit] do
+    resources :user_environment_roles, only: [:index]
+  end
 
   resources :audits, only: [:index, :show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Samson::Application.routes.draw do
     resources :webhooks, only: [:index, :create, :update, :destroy]
     resources :outbound_webhooks, only: [:index, :create, :update, :destroy]
     resources :references, only: [:index]
-    resources :user_environment_roles, only: [:index]
+    resources :user_project_roles, only: [:index]
 
     member do
       get :deploy_group_versions

--- a/db/migrate/20190927195246_create_user_environment_roles.rb
+++ b/db/migrate/20190927195246_create_user_environment_roles.rb
@@ -1,0 +1,10 @@
+class CreateUserEnvironmentRoles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_environment_roles do |t|
+      t.belongs_to :environment, null: false, index: true
+      t.belongs_to :user,        null: false, index: true
+      t.integer :role_id,        null: false
+      t.timestamps               null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_27_154835) do
+ActiveRecord::Schema.define(version: 2019_09_27_195246) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 2019_06_27_154835) do
     t.integer "deploy_group_id"
     t.decimal "limits_cpu", precision: 6, scale: 2, null: false
     t.integer "limits_memory", null: false
-    t.text "resource_template", limit: 1073741823
+    t.text "resource_template", limit: 4294967295
     t.decimal "requests_cpu", precision: 6, scale: 2, null: false
     t.integer "requests_memory", null: false
     t.boolean "delete_resource", default: false, null: false
@@ -581,6 +581,16 @@ ActiveRecord::Schema.define(version: 2019_06_27_154835) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
+  end
+
+  create_table "user_environment_roles" do |t|
+    t.bigint "environment_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "role_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["environment_id"], name: "index_user_environment_roles_on_environment_id"
+    t.index ["user_id"], name: "index_user_environment_roles_on_user_id"
   end
 
   create_table "user_project_roles", id: :integer do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_195246) do
     t.integer "deploy_group_id"
     t.decimal "limits_cpu", precision: 6, scale: 2, null: false
     t.integer "limits_memory", null: false
-    t.text "resource_template", limit: 4294967295
+    t.text "resource_template", limit: 1073741823
     t.decimal "requests_cpu", precision: 6, scale: 2, null: false
     t.integer "requests_memory", null: false
     t.boolean "delete_resource", default: false, null: false

--- a/test/controllers/concerns/current_environment_test.rb
+++ b/test/controllers/concerns/current_environment_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+class CurrentEnvironmentConcernTest < ActionController::TestCase
+  class CurrentEnvironmentTestController < ApplicationController
+    include CurrentEnvironment
+
+    def show
+      render inline: '<%= current_environment.class.name %>'
+    end
+  end
+
+  tests CurrentEnvironmentTestController
+  use_test_routes CurrentEnvironmentTestController
+
+  let(:environment) { environments(:production) }
+
+  before { login_as(users(:viewer)) }
+
+  it "finds current environment" do
+    get :show, params: {environment_id: environment.id, test_route: true}
+    response.body.must_equal 'Environment'
+  end
+
+  it "fails with invalid environment id" do
+    assert_raises ActiveRecord::RecordNotFound do
+      get :show, params: {environment_id: 123456, test_route: true}
+    end
+  end
+
+  it "does not fail without environment" do
+    get :show, params: {test_route: true}
+    response.body.must_equal 'NilClass'
+  end
+end

--- a/test/controllers/user_environment_roles_controller_test.rb
+++ b/test/controllers/user_environment_roles_controller_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe UserEnvironmentRolesController do
+  let(:environment) { environments(:production) }
+
+  as_a :viewer do
+    describe "#index" do
+      it 'renders' do
+        get :index, params: {environment_id: environment.to_param}
+        assert_template :index
+        assigns(:users).size.must_equal User.count
+      end
+
+      it 'renders JSON' do
+        get :index, params: {environment_id: environment.to_param, format: 'json'}
+        users = JSON.parse(response.body).fetch('users')
+        users.size.must_equal User.count
+      end
+
+      it 'filters' do
+        get :index, params: {environment_id: environment.to_param, search: "Admin"}
+        assert_template :index
+        users = assigns(:users).sort_by(&:name)
+        users.map(&:name).sort.must_equal ["Admin", "Deployer Project Admin", "Super Admin"]
+        users.first.user_environment_role_id.must_equal nil
+      end
+
+      it 'filters by role' do
+        get :index, params: {environment_id: environment.to_param, role_id: Role::ADMIN.id}
+        assert_template :index
+        assigns(:users).map(&:name).sort.must_equal ["Admin", "Super Admin"]
+      end
+
+      it 'filters by environment role' do
+        role = UserEnvironmentRole.create!(role_id: Role::DEPLOYER.id, environment: environments(:production), user: users(:deployer))
+        get :index, params: {environment_id: environment.to_param, role_id: Role::DEPLOYER.id}
+        assert_template :index
+        assigns(:users).map(&:name).sort.must_equal ["Admin",
+                                                    "Deployer",
+                                                    "Deployer Project Admin",
+                                                    "DeployerBuddy",
+                                                    "Environment Deployer Global Deployer",
+                                                    "Environment Deployer Global Viewer",
+                                                    "Environment Limited Project Deployer",
+                                                    "Environment Viewer Global Deployer",
+                                                    "Super Admin"]
+        assigns(:users).map(&:user_environment_role_id).must_include role.role_id
+      end
+    end
+  end
+
+  as_a :deployer do
+    unauthorized :post, :create, environment_id: :production
+  end
+
+  as_a :admin do
+    describe "#create" do
+      def create(role_id, **options)
+        post :create, params: {environment_id: environment, user_id: new_viewer.id, role_id: role_id}, **options
+      end
+
+      let(:new_viewer) { users(:deployer) }
+
+      it 'creates new environment role' do
+        create Role::VIEWER.id
+        assert_response :redirect
+        role = new_viewer.user_environment_roles.first
+        role.role_id.must_equal Role::VIEWER.id
+      end
+
+      it 'updates existing role' do
+        new_viewer.user_environment_roles.create!(role_id: Role::DEPLOYER.id, environment: environment)
+        create Role::VIEWER.id
+        assert_response :redirect
+        role = new_viewer.user_environment_roles.first.reload
+        role.role_id.must_equal Role::VIEWER.id
+      end
+
+      it 'deletes existing role when setting to None' do
+        new_viewer.user_environment_roles.create!(role_id: Role::DEPLOYER.id, environment: environment)
+        create ''
+        assert_response :redirect
+        refute new_viewer.reload.user_environment_roles.first
+      end
+
+      it 'does nothing when setting from None to None' do
+        create ''
+        assert_response :redirect
+        refute new_viewer.user_environment_roles.first
+      end
+
+      it 'clears the access request pending flag' do
+        check_pending_request_flag(new_viewer) do
+          create Role::VIEWER.id
+          assert_response :redirect
+        end
+      end
+
+      it 'renders text for xhr requests' do
+        create Role::VIEWER.id, xhr: true
+        assert_response :success
+      end
+    end
+  end
+
+  private
+
+  def check_pending_request_flag(user)
+    user.update!(access_request_pending: true)
+    assert(user.access_request_pending)
+    yield
+    user.reload
+    refute(user.access_request_pending)
+  end
+end

--- a/test/fixtures/user_environment_roles.yml
+++ b/test/fixtures/user_environment_roles.yml
@@ -1,0 +1,14 @@
+environment_limited_project_deployer:
+  user: environment_limited_project_deployer
+  environment: production
+  role_id: <%= Role::VIEWER.id %>
+
+environment_limited_viewer:
+  user: environment_limited_viewer
+  environment: production
+  role_id: <%= Role::DEPLOYER.id %>
+
+environment_limited_deployer:
+  user: environment_limited_viewer
+  environment: production
+  role_id: <%= Role::VIEWER.id %>

--- a/test/fixtures/user_environment_roles.yml
+++ b/test/fixtures/user_environment_roles.yml
@@ -13,12 +13,7 @@ environment_viewer_global_deployer:
   environment: production
   role_id: <%= Role::VIEWER.id %>
 
-environment_deployer_global_admin:
-  user: environment_deployer_global_admin
+environment_deployer_global_deployer:
+  user: environment_deployer_global_deployer
   environment: production
   role_id: <%= Role::DEPLOYER.id %>
-
-environment_viewer_global_admin:
-  user: environment_viewer_global_admin
-  environment: production
-  role_id: <%= Role::VIEWER.id %>

--- a/test/fixtures/user_environment_roles.yml
+++ b/test/fixtures/user_environment_roles.yml
@@ -3,12 +3,22 @@ environment_limited_project_deployer:
   environment: production
   role_id: <%= Role::VIEWER.id %>
 
-environment_limited_viewer:
-  user: environment_limited_viewer
+environment_deployer_global_viewer:
+  user: environment_deployer_global_viewer
   environment: production
   role_id: <%= Role::DEPLOYER.id %>
 
-environment_limited_deployer:
-  user: environment_limited_viewer
+environment_viewer_global_deployer:
+  user: environment_viewer_global_deployer
+  environment: production
+  role_id: <%= Role::VIEWER.id %>
+
+environment_deployer_global_admin:
+  user: environment_deployer_global_admin
+  environment: production
+  role_id: <%= Role::DEPLOYER.id %>
+
+environment_viewer_global_admin:
+  user: environment_viewer_global_admin
   environment: production
   role_id: <%= Role::VIEWER.id %>

--- a/test/fixtures/user_project_roles.yml
+++ b/test/fixtures/user_project_roles.yml
@@ -7,3 +7,8 @@ project_deployer:
   user: project_deployer
   project: test
   role_id: <%= Role::DEPLOYER.id %>
+
+environment_limited_project_deployer:
+  user: environment_limited_project_deployer
+  project: test
+  role_id: <%= Role::DEPLOYER.id %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -66,30 +66,23 @@ environment_limited_project_deployer:
   external_id: 'github-5'
   <<: *DEFAULTS
 
-environment_deployer_global_admin:
-  name: "Environment Limited Admin"
-  email: "admin_limited@example.com"
-  role_id: <%= Role::ADMIN.id %>
+environment_deployer_global_deployer:
+  name: "Environment Deployer Global Deployer"
+  email: "deployer_limited_deployer@example.com"
+  role_id: <%= Role::DEPLOYER.id %>
   external_id: 'google-3'
   <<: *DEFAULTS
 
 environment_deployer_global_viewer:
-  name: "Environment Limited Viewer"
+  name: "Environment Deployer Global Viewer"
   email: "viewer_limited@example.com"
   role_id: <%= Role::VIEWER.id %>
   external_id: 'google-3'
   <<: *DEFAULTS
 
 environment_viewer_global_deployer:
-  name: "Environment Limited Deployer"
+  name: "Environment Viewer Global Deployer"
   email: "deployer_limited@example.com"
   role_id: <%= Role::DEPLOYER.id %>
-  external_id: 'google-3'
-  <<: *DEFAULTS
-
-environment_viewer_global_admin:
-  name: "Environment Limited Admin"
-  email: "admin_limited_to_viewer@example.com"
-  role_id: <%= Role::ADMIN.id %>
   external_id: 'google-3'
   <<: *DEFAULTS

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -58,3 +58,24 @@ project_deployer:
   role_id: <%= Role::VIEWER.id %>
   external_id: 'github-5'
   <<: *DEFAULTS
+
+environment_limited_project_deployer:
+  name: "Environment Limited Project Deployer"
+  email: "viewer_deployer_limited@example.com"
+  role_id: <%= Role::DEPLOYER.id %>
+  external_id: 'github-5'
+  <<: *DEFAULTS
+
+environment_limited_viewer:
+  name: "Environment Limited Viewer"
+  email: "viewer_limited@example.com"
+  role_id: <%= Role::VIEWER.id %>
+  external_id: 'google-3'
+  <<: *DEFAULTS
+
+environment_limited_deployer:
+  name: "Environment Limited Deployer"
+  email: "deployer_limited@example.com"
+  role_id: <%= Role::DEPLOYER.id %>
+  external_id: 'google-3'
+  <<: *DEFAULTS

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -66,16 +66,30 @@ environment_limited_project_deployer:
   external_id: 'github-5'
   <<: *DEFAULTS
 
-environment_limited_viewer:
+environment_deployer_global_admin:
+  name: "Environment Limited Admin"
+  email: "admin_limited@example.com"
+  role_id: <%= Role::ADMIN.id %>
+  external_id: 'google-3'
+  <<: *DEFAULTS
+
+environment_deployer_global_viewer:
   name: "Environment Limited Viewer"
   email: "viewer_limited@example.com"
   role_id: <%= Role::VIEWER.id %>
   external_id: 'google-3'
   <<: *DEFAULTS
 
-environment_limited_deployer:
+environment_viewer_global_deployer:
   name: "Environment Limited Deployer"
   email: "deployer_limited@example.com"
   role_id: <%= Role::DEPLOYER.id %>
+  external_id: 'google-3'
+  <<: *DEFAULTS
+
+environment_viewer_global_admin:
+  name: "Environment Limited Admin"
+  email: "admin_limited_to_viewer@example.com"
+  role_id: <%= Role::ADMIN.id %>
   external_id: 'google-3'
   <<: *DEFAULTS

--- a/test/helpers/stages_helper_test.rb
+++ b/test/helpers/stages_helper_test.rb
@@ -28,5 +28,14 @@ describe StagesHelper do
       stage_template_icon.must_include "glyphicon-duplicate"
     end
   end
+
+  describe "#deployer_for_stage?" do
+    let(:current_user) { users(:deployer) }
+
+    it "works" do
+      @project = projects(:test)
+      deployer_for_stage?(stages(:test_staging)).must_equal true
+    end
+  end
 end
 # rubocop:enable Metrics/LineLength

--- a/test/helpers/user_environment_roles_helper_test.rb
+++ b/test/helpers/user_environment_roles_helper_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe UserEnvironmentRolesHelper do
+  let(:environment) { environments(:test) }
+
+  describe "#user_environment_role_radio" do
+    it "allows downgrade for unchecked" do
+      result = user_environment_role_radio users(:deployer), 'Foo', Role::VIEWER.id, nil
+      result.wont_include 'checked'
+      result.wont_include 'global'
+      result.wont_include 'disabled="disabled"'
+    end
+
+    context "with global access" do
+      it "blocks upgrades" do
+        result = user_environment_role_radio users(:viewer), 'Foo', Role::DEPLOYER.id, nil
+        result.wont_include 'checked'
+        result.must_include 'global'
+        result.must_include 'disabled="disabled"'
+      end
+
+      it "allows downgrades" do
+        result = user_environment_role_radio users(:deployer), 'Foo', Role::VIEWER.id, nil
+        result.wont_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+    end
+
+    context 'with environment access' do
+      it "allows to re-check current" do
+        result = user_environment_role_radio users(:environment_viewer_global_deployer), 'Foo', Role::VIEWER.id, Role::VIEWER.id
+        result.must_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+
+      it "allows downgrades" do
+        result = user_environment_role_radio users(:environment_deployer_global_admin), 'Foo', Role::VIEWER.id, Role::DEPLOYER.id
+        result.must_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+
+      it "allows upgrade" do
+        result = user_environment_role_radio users(:environment_viewer_global_admin), 'Foo', Role::DEPLOYER.id, Role::VIEWER.id
+        result.wont_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+    end
+  end
+end

--- a/test/helpers/user_environment_roles_helper_test.rb
+++ b/test/helpers/user_environment_roles_helper_test.rb
@@ -39,14 +39,14 @@ describe UserEnvironmentRolesHelper do
       end
 
       it "allows downgrades" do
-        result = user_environment_role_radio users(:environment_deployer_global_admin), 'Foo', Role::VIEWER.id, Role::DEPLOYER.id
+        result = user_environment_role_radio users(:environment_deployer_global_deployer), 'Foo', Role::VIEWER.id, Role::DEPLOYER.id
         result.must_include 'checked'
         result.wont_include 'global'
         result.wont_include 'disabled="disabled"'
       end
 
       it "allows upgrade" do
-        result = user_environment_role_radio users(:environment_viewer_global_admin), 'Foo', Role::DEPLOYER.id, Role::VIEWER.id
+        result = user_environment_role_radio users(:environment_viewer_global_deployer), 'Foo', Role::DEPLOYER.id, Role::VIEWER.id
         result.wont_include 'checked'
         result.wont_include 'global'
         result.wont_include 'disabled="disabled"'

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -591,8 +591,8 @@ describe Project do
 
   describe "#user_project_roles" do
     it "deletes them on deletion and audits as user change" do
-      assert_difference 'Audited::Audit.where(auditable_type: "User").count', +2 do
-        assert_difference 'UserProjectRole.count', -2 do
+      assert_difference 'Audited::Audit.where(auditable_type: "User").count', +3 do
+        assert_difference 'UserProjectRole.count', -3 do
           project.soft_delete!(validate: false)
         end
       end

--- a/test/models/user_environment_role_test.rb
+++ b/test/models/user_environment_role_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe UserEnvironmentRole do
+  let(:user) { users(:viewer) }
+  let(:environment) { environments(:staging) }
+  let!(:environment_role) { UserEnvironmentRole.create!(user_id: user.id, environment_id: environment.id, role_id: Role::DEPLOYER.id) }
+
+  describe "creates a new environment role from a hash" do
+    it "is persisted" do
+      environment_role.persisted?.must_equal(true)
+    end
+
+    it "it created the mapping with the user and the environment" do
+      environment_role.user.wont_be_nil
+      environment_role.environment.wont_be_nil
+    end
+  end
+
+  describe "fails to create an environment role with an invalid role" do
+    let(:invalid_role) { UserEnvironmentRole.create(user_id: user.id, environment_id: environment.id, role_id: 3) }
+
+    it "is not persisted" do
+      invalid_role.persisted?.must_equal(false)
+    end
+
+    it "contains errors" do
+      invalid_role.errors.wont_be_empty
+    end
+  end
+
+  describe "fails to create yet another environment role for same user and environment" do
+    let(:another_role) { UserEnvironmentRole.create(user_id: user.id, environment_id: environment.id, role_id: Role::DEPLOYER.id) }
+
+    it "is not persisted" do
+      another_role.persisted?.must_equal(false)
+    end
+
+    it "contains errors" do
+      another_role.errors.wont_be_empty
+    end
+  end
+
+  describe "updates an existing environment role" do
+    before do
+      environment_role.update(role_id: Role::DEPLOYER.id)
+    end
+
+    it "does not update the user" do
+      environment_role.user.must_equal user
+    end
+
+    it "does not update the environment" do
+      environment_role.environment.must_equal environment
+    end
+
+    it "updated the role" do
+      environment_role.role_id.must_equal Role::DEPLOYER.id
+    end
+  end
+
+  describe "fails to update an environment role with an invalid role" do
+    before do
+      environment_role.update(role_id: 3)
+    end
+
+    it "is persisted" do
+      environment_role.persisted?.must_equal(true)
+    end
+
+    it "contains errors" do
+      environment_role.errors.wont_be_empty
+    end
+  end
+
+  describe "audits" do
+    it "tracks important changes" do
+      environment_role.audits.size.must_equal 1
+      environment_role.update_attributes!(role_id: 0)
+      environment_role.audits.size.must_equal 2
+    end
+
+    it "ignores unimportant changes" do
+      environment_role.update_attributes!(updated_at: 1.second.from_now)
+      environment_role.audits.size.must_equal 1
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -256,20 +256,20 @@ describe User do
     end
 
     it "filters everything when asking for a unreachable role" do
-      User.with_role(Role::SUPER_ADMIN.id + 1, project.id).size.must_equal 0
+      User.with_role(Role::SUPER_ADMIN.id + 1, project.id, :project).size.must_equal 0
     end
 
     it "filters nothing when asking for anything" do
-      User.with_role(Role::VIEWER.id, project.id).size.must_equal User.count
+      User.with_role(Role::VIEWER.id, project.id, :project).size.must_equal User.count
     end
 
     it 'filters by deployer' do
-      User.with_role(Role::DEPLOYER.id, project.id).map(&:name).sort.must_equal \
+      User.with_role(Role::DEPLOYER.id, project.id, :project).map(&:name).sort.must_equal \
         deployer_list
     end
 
     it 'filters by admin' do
-      User.with_role(Role::ADMIN.id, project.id).map(&:name).sort.must_equal \
+      User.with_role(Role::ADMIN.id, project.id, :project).map(&:name).sort.must_equal \
         ["Admin", "Deployer Project Admin", "Super Admin"]
     end
 
@@ -284,13 +284,13 @@ describe User do
 
       it 'does not show duplicate when multiple roles exist' do
         UserProjectRole.create!(user: users(:project_admin), project: other, role_id: Role::ADMIN.id)
-        User.with_role(Role::DEPLOYER.id, project.id).map(&:name).sort.must_equal \
+        User.with_role(Role::DEPLOYER.id, project.id, :project).map(&:name).sort.must_equal \
           deployer_list
       end
 
       it 'shows users that only have a role on different projects' do
         UserProjectRole.create!(user: users(:deployer), project: other, role_id: Role::ADMIN.id)
-        User.with_role(Role::DEPLOYER.id, project.id).map(&:name).sort.must_equal \
+        User.with_role(Role::DEPLOYER.id, project.id, :project).map(&:name).sort.must_equal \
           deployer_list
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -250,6 +250,8 @@ describe User do
         "Deployer",
         "Deployer Project Admin",
         "DeployerBuddy",
+        "Environment Limited Deployer",
+        "Environment Limited Project Deployer",
         "Project Deployer",
         "Super Admin"
       ]
@@ -324,23 +326,52 @@ describe User do
     end
   end
 
-  describe "#deployer_for_project?" do
-    it "is true for a user that has been granted the role of project deployer" do
-      users(:project_deployer).deployer_for?(projects(:test)).must_equal(true)
+  describe "#deployer_for?" do
+    context 'when the user has been granted the role of project deployer' do
+      context 'when there are no environment role limitations' do
+        it "is true" do
+          users(:project_deployer).deployer_for?(projects(:test)).must_equal(true)
+        end
+      end
+      context 'when there are environment role limitations' do
+        it "is true" do
+          users(:environment_limited_project_deployer).deployer_for?(projects(:test), environments(:production)).must_equal(false)
+        end
+      end
     end
 
-    it "is true for a user that has been granted the role of project admin" do
-      users(:project_admin).deployer_for?(projects(:test)).must_equal(true)
+    context 'when the user has been granted the role of project admin' do
+      it "is true" do
+        users(:project_admin).deployer_for?(projects(:test)).must_equal(true)
+      end
     end
 
-    it "is false for users that have not been granted the roles of project deployer or project admin" do
-      users(:viewer).deployer_for?(projects(:test)).must_equal(false)
+    context 'when the user has not been granted the role of project deployer or project admin' do
+      context 'when there are no environment role limitations' do
+        it "is false" do
+          users(:viewer).deployer_for?(projects(:test)).must_equal(false)
+        end
+      end
+      context 'when there are environment role limitations placing you above viewer' do
+        it "is still false" do
+          users(:environment_limited_viewer).deployer_for?(projects(:test), environments(:production)).must_equal(false)
+        end
+      end
     end
 
-    it "is true for deployers" do
-      users(:deployer).deployer_for?(projects(:test)).must_equal(true)
-      users(:admin).deployer_for?(projects(:test)).must_equal(true)
-      users(:super_admin).deployer_for?(projects(:test)).must_equal(true)
+    context 'when the user is a global deployer' do
+      context 'when there are no environment role limitations' do
+        it "is true" do
+          users(:deployer).deployer_for?(projects(:test)).must_equal(true)
+          users(:admin).deployer_for?(projects(:test)).must_equal(true)
+          users(:super_admin).deployer_for?(projects(:test)).must_equal(true)
+        end
+      end
+      context 'when there are environment role limitations' do
+        it 'is false' do
+          users(:environment_limited_deployer).deployer_for?(projects(:test), environments(:production)).must_equal(true)
+        end
+      end
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -250,8 +250,9 @@ describe User do
         "Deployer",
         "Deployer Project Admin",
         "DeployerBuddy",
-        "Environment Limited Deployer",
+        "Environment Deployer Global Deployer",
         "Environment Limited Project Deployer",
+        "Environment Viewer Global Deployer",
         "Project Deployer",
         "Super Admin"
       ]
@@ -354,7 +355,7 @@ describe User do
       end
       context 'when there are environment role limitations placing you above viewer' do
         it "is still false" do
-          users(:environment_limited_viewer).deployer_for?(projects(:test), environments(:production)).must_equal(false)
+          users(:environment_deployer_global_viewer).deployer_for?(projects(:test), environments(:production)).must_equal(false)
         end
       end
     end
@@ -369,7 +370,7 @@ describe User do
       end
       context 'when there are environment role limitations' do
         it 'is false' do
-          users(:environment_limited_deployer).deployer_for?(projects(:test), environments(:production)).must_equal(true)
+          users(:environment_viewer_global_deployer).deployer_for?(projects(:test), environments(:production)).must_equal(false)
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ require 'minitest/rails'
 require 'rails-controller-testing'
 Rails::Controller::Testing.install
 require 'maxitest/autorun'
-# require 'maxitest/timeout'
+require 'maxitest/timeout'
 require 'maxitest/threads'
 require 'webmock/minitest'
 require 'mocha/setup'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] = "test"
 
 require 'bundler/setup'
+require 'pry'
 
 # anything loaded before coverage will be uncovered
 require 'single_cov'
@@ -18,7 +19,7 @@ require 'minitest/rails'
 require 'rails-controller-testing'
 Rails::Controller::Testing.install
 require 'maxitest/autorun'
-require 'maxitest/timeout'
+# require 'maxitest/timeout'
 require 'maxitest/threads'
 require 'webmock/minitest'
 require 'mocha/setup'


### PR DESCRIPTION
This allows you to have, for example, global deployers or project deployers that can not deploy on production.
Disclaimer: some of the practices here are meant to keep consistency with patterns in the samson codebase, rather than follow lumos' practices  (or my own preferences). Even if we never merge this into zendesk/samson's master, I thought it was better to keep it homogeneous to make potential future development easier.

Also, master is already red. I took care to not bring new errors into tests, but making master pass is a whole other can of worms.